### PR TITLE
Changing versions of kirigami and removing subtitle

### DIFF
--- a/plasmoid/contents/ui/ConfigSymbolSearchPage.qml
+++ b/plasmoid/contents/ui/ConfigSymbolSearchPage.qml
@@ -22,7 +22,7 @@ import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.12
 import QtQml.Models 2.12
 import org.kde.plasma.components 2.0 as PlasmaComponents
-import org.kde.kirigami 2.12 as Kirigami
+import org.kde.kirigami 2.5 as Kirigami
 import "../code/yahoofinance.mjs" as YahooFinance
 
 Page {
@@ -72,8 +72,7 @@ Page {
                 spacing: Kirigami.Units.smallSpacing
                 model: ListModel { id: searchQuotesModel }
                 delegate: Kirigami.BasicListItem {
-                    label: symbol
-                    subtitle: `${longName} (${exchange}) (${instrument})`
+                    label: `${symbol}: ${longName} (${exchange}) (${instrument})`
 
                     onClicked: {
                         if (symbols.indexOf(symbol) !== -1) {


### PR DESCRIPTION
This change is necessary to be able to run the plasmoid into KDE on Ubuntu/Kubuntu 20.04

![image](https://user-images.githubusercontent.com/5624499/117557039-b405d080-b034-11eb-9092-957522906c43.png)
